### PR TITLE
Added option to return in html format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Whatsapp Editor
-The plugin allows user to format text online. The result text can be directly sent to whatsapp API which will be consistent against format.
+The plugin allows user to format text online. The result text can be directly sent to whatsapp API which will be consistent against format, or show in the browser to be sent, in text format, to the WhatsApp web.
 
 ## Usage
 1. Include jQuery
@@ -29,6 +29,7 @@ var content=editor.getFormattedContent(); // Formatted WhatsApp content
 * italic: Allows user to select text and mark them as *Italic*
 * Strikethrough: Allows user to select text and mark them as ~Strikethrough~
 * Monospace: Allows user to select text and mark them as `Monospace`
+* html_contet: Allows user to return text in html format. Default is **false**
 * Content: Allows developer to specify default text for converting to whatsapp type text.
 
 For more information see index.html file.

--- a/src/js/whatsapp-editor.js
+++ b/src/js/whatsapp-editor.js
@@ -7,6 +7,7 @@
             strikethrough: true,
             monospace: true,
             smiles: true,
+            html_content: false,
             content: ''
         }, options);
 
@@ -120,12 +121,17 @@
         function prepareFormattedContent(htmlContent) {
             htmlContent = htmlContent
                 .replace(/<b>|<\/b>/g, '*') // BOLD
-                .replace(/<div>|<br>|<br\/>/g, '\n')    // LINE BREAK
-                .replace(/<\/div>/g, '')
                 .replace(/<i>|<\/i>/g, '_') // Italic
                 .replace(/<strike>|<\/strike>/g, '~')
-                .replace(/<font face="monospace" style="">|<font face="monospace">|<\/font>/g, '```')
-                .replace(/<[^>]*>/g, "");    // Strike Through
+                .replace(/<font face="monospace" style="">|<font face="monospace">|<\/font>/g, '```');
+                
+            if (!settings.html_content) {
+                htmlContent = htmlContent
+                    .replace(/<div>|<br>|<br\/>/g, '\n')    // LINE BREAK
+                    .replace(/<\/div>/g, '')
+                    .replace(/<[^>]*>/g, "");    // Strike Through
+            }
+            
             return htmlContent;
         }
 


### PR DESCRIPTION
When presenting in a browser, the return did not skip lines as it did not come in HTML format. Added the option to return the same in this format so that it can be presented in the browser with the line breaks.

![GravaÃ§Ã£o de Tela 2021-07-13 Ã s 22 06 40](https://user-images.githubusercontent.com/1373275/125549742-e151d508-d3d8-4eea-b83b-079499df6c42.gif)


The README is updated too.